### PR TITLE
Update: 메시지 읽음 처리 동기화 및 채팅방 Redis Collection 변경

### DIFF
--- a/client/src/components/ChatDetailLayer.vue
+++ b/client/src/components/ChatDetailLayer.vue
@@ -289,13 +289,6 @@ export default {
                 }
 
                 if (_.includes(['lookup', 'message', 'file', 'invite'], json.type)) {
-                    const data = {
-                        'type': 'update',
-                        'data': {
-                            'is_read': true
-                        }
-                    };
-                    wsSend(data);
                     // 스크롤 이동
                     nextTick(() => {
                         setTimeout(() => moveChatBodyPosition(), 50);

--- a/client/src/components/ChatDetailLayer.vue
+++ b/client/src/components/ChatDetailLayer.vue
@@ -644,7 +644,7 @@ export default {
 }
 
 .chat-notice-container {
-    height: 60px;
+    height: 45px;
     color: #757575;
     display: flex;
     flex-direction: column;

--- a/server/api/common.py
+++ b/server/api/common.py
@@ -9,6 +9,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import joinedload, selectinload
 from starlette import status
 from starlette.websockets import WebSocket
+from websockets.exceptions import WebSocketException
 
 from server.core.authentications import COOKIE_NAME, cookie, backend
 from server.core.enums import IntValueEnum
@@ -16,8 +17,8 @@ from server.core.externals.redis import AioRedis
 from server.core.externals.redis.schemas import (
     RedisChatRoomByUserProfileS, RedisChatRoomsByUserProfileS, RedisUserProfilesByRoomS,
     RedisChatHistoriesByRoomS, RedisChatHistoriesToSyncS, RedisUserImageFileS,
-    RedisChatHistoryFileS, RedisUserProfileByRoomS, RedisChatHistoryByRoomS, RedisChatRoomInfoS,
-    RedisChatRoomsInfoS
+    RedisChatHistoryFileS, RedisUserProfileByRoomS, RedisChatHistoryByRoomS, RedisInfoByRoomS,
+    RedisChatRoomInfoS
 )
 from server.crud.service import ChatRoomCRUD, ChatRoomUserAssociationCRUD
 from server.models import (
@@ -156,8 +157,7 @@ class RedisHandler:
     ) -> Tuple[RedisChatRoomInfoS, Pipeline | None]:
         async def _action():
             callback_pipe = None
-            rooms_redis: List[RedisChatRoomInfoS] = await RedisChatRoomsInfoS.smembers(self.redis, None)
-            room_redis: RedisChatRoomInfoS = next((r for r in rooms_redis if r.id == room_id), None)
+            room_redis: RedisChatRoomInfoS = await RedisInfoByRoomS.hgetall(self.redis, room_id)
             if not room_redis and sync:
                 room_db: ChatRoom = await crud.get(
                     conditions=(ChatRoom.id == room_id,),
@@ -169,13 +169,13 @@ class RedisHandler:
                 )
                 if room_db and room_db.is_active:
                     async def _transaction(pipeline: Pipeline):
-                        return await RedisChatRoomsInfoS.sadd(
-                            pipeline, None, RedisChatRoomsInfoS.schema(
+                        return await RedisInfoByRoomS.hset(
+                            pipeline, room_id, data=RedisChatRoomInfoS(
                                 id=room_db.id, type=room_db.type.name.lower(),
                                 user_profile_ids=[m.user_profile_id for m in room_db.user_profiles],
                                 user_profile_files=await self.generate_profile_images_schema(
                                     [m.user_profile for m in room_db.user_profiles], only_default=True
-                                )
+                                ), connected_profile_ids=[]
                             )
                         )
 
@@ -190,53 +190,7 @@ class RedisHandler:
             return room_redis, callback_pipe
 
         if lock:
-            async with self.lock(key=RedisChatRoomsInfoS.get_lock_key()):
-                return await _action()
-        return await _action()
-
-    async def get_rooms(
-        self,
-        crud: Optional[ChatRoomCRUD] = None,
-        pipe: Optional[Pipeline] = None,
-        sync=False, lock=True, raise_exception=False
-    ) -> Tuple[List[RedisChatRoomInfoS], Pipeline | None]:
-        async def _action():
-            callback_pipe = None
-            rooms_redis: List[RedisChatRoomInfoS] = await RedisChatRoomsInfoS.smembers(self.redis, None)
-            if not rooms_redis and sync:
-                rooms_db: List[ChatRoom] = await crud.list(
-                    options=[
-                        selectinload(ChatRoom.user_profiles)
-                        .joinedload(ChatRoomUserAssociation.user_profile)
-                        .selectinload(UserProfile.images)
-                    ]
-                )
-                if rooms_db:
-                    async def _transaction(pipeline: Pipeline):
-                        return await RedisChatRoomsInfoS.sadd(
-                            pipeline, None, *[
-                                RedisChatRoomsInfoS.schema(
-                                    id=room_db.id, type=room_db.type.name.lower(),
-                                    user_profile_ids=[m.user_profile_id for m in room_db.user_profiles],
-                                    user_profile_files=await self.generate_profile_images_schema(
-                                        [m.user_profile for m in room_db.user_profiles], only_default=True
-                                    )
-                                ) for room_db in rooms_db if room_db.is_active
-                            ]
-                        )
-
-                    if not pipe:
-                        async with self.pipeline(transaction=True) as _pipe:
-                            await (await _transaction(_pipe)).execute()
-                    else:
-                        callback_pipe = await _transaction(pipe)
-
-                elif raise_exception:
-                    raise HTTPException(status_code=status.HTTP_404_NOT_FOUND)
-            return rooms_redis, callback_pipe
-
-        if lock:
-            async with self.lock(key=RedisChatRoomsInfoS.get_lock_key()):
+            async with self.lock(key=RedisInfoByRoomS.get_lock_key()):
                 return await _action()
         return await _action()
 
@@ -462,16 +416,46 @@ class RedisHandler:
         else:
             return await _transaction(pipe)
 
+    # 유저 채팅방 unread_msg_cnt 업데이트
+    async def update_unread_msg_cnt(
+        self,
+        room_id: int,
+        profile_id: int,
+        crud: ChatRoomUserAssociationCRUD,
+        timestamp: Optional[float] = None
+    ):
+        async with self.lock(key=RedisChatRoomsByUserProfileS.get_lock_key(profile_id)):
+            room_by_profile_redis, _ = await self.get_room_by_user_profile(
+                room_id, profile_id, crud, sync=True, lock=False
+            )
+            if room_by_profile_redis:
+                async with self.pipeline() as pipe:
+                    pipe = await RedisChatRoomsByUserProfileS.zrem(
+                        pipe, profile_id, room_by_profile_redis
+                    )
+                    pipe = await RedisChatRoomsByUserProfileS.zadd(
+                        pipe, profile_id, RedisChatRoomByUserProfileS(
+                            id=room_by_profile_redis.id,
+                            name=room_by_profile_redis.name,
+                            unread_msg_cnt=room_by_profile_redis.unread_msg_cnt + 1,
+                            timestamp=timestamp or datetime.now().astimezone().timestamp()
+                        )
+                    )
+                    await pipe.execute()
+
     async def handle_pubsub(self, ws: WebSocket, producer_handler: Callable, consumer_handler: Callable, logger):
         pubsub: PubSub = self.redis.pubsub()
         producer_task: Coroutine = producer_handler(pub=self.redis, ws=ws)
         consumer_task: Coroutine = consumer_handler(psub=pubsub, ws=ws)
         done, pending = await asyncio.wait(
-            [producer_task, consumer_task], return_when=asyncio.FIRST_COMPLETED)
+            [producer_task, consumer_task], return_when=asyncio.FIRST_COMPLETED
+        )
         logger.info(f"Done task: {done}")
-        for task in pending:
-            logger.info(f"Canceling task: {task}")
-            task.cancel()
+        if pending:
+            for task in pending:
+                logger.info(f"Canceling task: {task}")
+                task.cancel()
+            raise WebSocketException('Cancelled task.')
 
 
 def generate_room_mapping_name(user_profile_id: int, other_profiles: List[UserProfile]):

--- a/server/api/common.py
+++ b/server/api/common.py
@@ -180,7 +180,7 @@ class RedisHandler:
                         )
 
                     if not pipe:
-                        async with self.pipeline(transaction=True) as _pipe:
+                        async with self.pipeline() as _pipe:
                             await (await _transaction(_pipe)).execute()
                     else:
                         callback_pipe = await _transaction(pipe)
@@ -224,7 +224,7 @@ class RedisHandler:
                         )
 
                     if not pipe:
-                        async with self.pipeline(transaction=True) as _pipe:
+                        async with self.pipeline() as _pipe:
                             await (await _transaction(_pipe)).execute()
                     else:
                         callback_pipeline = await _transaction(pipe)
@@ -274,7 +274,7 @@ class RedisHandler:
                         )
 
                     if not pipe:
-                        async with self.pipeline(transaction=True) as _pipe:
+                        async with self.pipeline() as _pipe:
                             await (await _transaction(_pipe)).execute()
                     else:
                         callback_pipe = await _transaction(pipe)
@@ -328,7 +328,7 @@ class RedisHandler:
                         )
 
                     if not pipe:
-                        async with self.pipeline(transaction=True) as _pipe:
+                        async with self.pipeline() as _pipe:
                             await (await _transaction(_pipe)).execute()
                     else:
                         callback_pipe = await _transaction(pipe)
@@ -383,7 +383,7 @@ class RedisHandler:
                             )
 
                         if not pipe:
-                            async with self.pipeline(transaction=True) as _pipe:
+                            async with self.pipeline() as _pipe:
                                 await (await _transaction(_pipe)).execute()
                         else:
                             callback_pipeline = await _transaction(pipe)
@@ -411,7 +411,7 @@ class RedisHandler:
             return pipeline
 
         if not pipe:
-            async with self.pipeline(transaction=True) as p:
+            async with self.pipeline() as p:
                 await (await _transaction(p)).execute()
         else:
             return await _transaction(pipe)

--- a/server/api/v1/chat.py
+++ b/server/api/v1/chat.py
@@ -357,7 +357,7 @@ async def chat_room_create(
             type=room.type.name.lower(),
             user_profile_ids=user_profile_ids,
             user_profile_files=default_profile_images,
-            connected_user_profile_ids=set(),
+            connected_profile_ids=[],
         ))
         await pipe.execute()
 

--- a/server/api/v1/chat.py
+++ b/server/api/v1/chat.py
@@ -7,7 +7,7 @@ from copy import deepcopy
 from datetime import datetime
 from io import BytesIO
 from itertools import groupby
-from typing import List, Set, Dict, Any, Optional
+from typing import List, Set, Dict, Any, Optional, Tuple
 
 from aioredis import Redis
 from aioredis.client import PubSub
@@ -18,7 +18,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import joinedload, selectinload
 from starlette import status
 from starlette.responses import HTMLResponse
-from websockets.exceptions import ConnectionClosedOK, ConnectionClosedError
+from websockets.exceptions import WebSocketException
 
 from server.api import ExceptionHandlerRoute, templates
 from server.api.common import AuthValidator, RedisHandler
@@ -29,9 +29,10 @@ from server.core.externals.redis.schemas import (
     RedisUserProfilesByRoomS,
     RedisChatHistoriesByRoomS, RedisUserProfileByRoomS, RedisChatHistoryByRoomS,
     RedisChatRoomsByUserProfileS, RedisChatHistoryFileS, RedisFollowingsByUserProfileS,
-    RedisFollowingByUserProfileS, RedisUserImageFileS, RedisChatRoomsInfoS, RedisChatRoomInfoS,
-    RedisChatRoomByUserProfileS, RedisChatHistoryPatchS
+    RedisFollowingByUserProfileS, RedisUserImageFileS, RedisChatRoomByUserProfileS, RedisChatHistoryPatchS,
+    RedisInfoByRoomS, RedisChatRoomInfoS
 )
+from server.core.utils import async_iter
 from server.crud.service import (
     ChatRoomUserAssociationCRUD, ChatRoomCRUD, ChatHistoryCRUD, ChatHistoryUserAssociationCRUD
 )
@@ -138,14 +139,9 @@ async def chat_rooms(
                         rooms_by_profile_redis.append(items[0])
 
                     rooms_by_profile_redis.sort(key=lambda x: x.timestamp, reverse=True)
-                    room_ids: List[int] = [r.id for r in rooms_by_profile_redis]
-                    total_rooms, _ = await redis_handler.get_rooms(redis_handler.redis, crud_room, lock=False, sync=True)
-                    rooms: List[RedisChatRoomInfoS] = [
-                        r for r in total_rooms if r.id in room_ids
-                    ] if total_rooms else []
                     for room_by_profile_redis in rooms_by_profile_redis:
-                        room: RedisChatRoomInfoS = next(
-                            (r for r in rooms if r.id == room_by_profile_redis.id), None
+                        room, _ = await redis_handler.get_room(
+                            room_by_profile_redis.id, crud_room, sync=True, lock=False
                         )
                         if not room:
                             continue
@@ -170,38 +166,7 @@ async def chat_rooms(
                         last_chat_history = None
                         if chat_histories:
                             last_chat_history = chat_histories[0]
-                        # else:
-                        #     crud_chat_history = ChatHistoryCRUD(session)
-                        #     chat_histories_db: List[ChatHistory] = await crud_chat_history.list(
-                        #         conditions=(ChatHistory.room_id == room_by_profile_redis.id,),
-                        #         order_by=(ChatHistory.created.desc(),),
-                        #         options=[
-                        #             selectinload(ChatHistory.files),
-                        #             selectinload(ChatHistory.user_profile_mapping)
-                        #         ],
-                        #         offset=0,
-                        #         limit=1
-                        #     )
-                        #     if chat_histories_db:
-                        #         last_chat_history = RedisChatHistoryByRoomS(
-                        #             id=chat_histories_db[0].id,
-                        #             user_profile_id=chat_histories_db[0].user_profile_id,
-                        #             contents=chat_histories_db[0].contents,
-                        #             type=chat_histories_db[0].type.name.lower(),
-                        #             files=await redis_handler.generate_presigned_files(
-                        #                 ChatHistoryFile, chat_histories_db[0].files
-                        #             ),
-                        #             read_user_ids=[
-                        #                 m.user_profile_id for m in chat_histories_db[0].user_profile_mapping
-                        #                 if m.is_read
-                        #             ],
-                        #             timestamp=chat_histories_db[0].created.timestamp(),
-                        #             date=chat_histories_db[0].created.date().isoformat(),
-                        #             is_active=chat_histories_db[0].is_active
-                        #         )
-                        #         await RedisChatHistoriesByRoomS.zadd(
-                        #             redis_handler.redis, room_by_profile_redis, last_chat_history
-                        #         )
+
                         obj: Dict[str, Any] = jsonable_encoder(room_by_profile_redis)
                         obj.update(jsonable_encoder({
                             'name': room_name,
@@ -213,7 +178,7 @@ async def chat_rooms(
                         }))
                         result.append(obj)
                 await websocket.send_json(result)
-            except (WebSocketDisconnect, ConnectionClosedOK, ConnectionClosedError) as e:
+            except (WebSocketDisconnect, WebSocketException) as e:
                 logger.exception(get_log_error(e))
                 raise e
             except Exception as e:
@@ -386,19 +351,14 @@ async def chat_room_create(
                         ) for n in room.user_profiles
                     ]
                 )
-        async with redis_handler.lock(key=RedisChatRoomsInfoS.get_lock_key()):
-            rooms_info_redis: List[RedisChatRoomInfoS] = await RedisChatRoomsInfoS.smembers(redis_handler.redis, None)
-            filtered_rooms_info_redis = [r for r in rooms_info_redis if r.id == room.id]
-            if filtered_rooms_info_redis:
-                pipe = await RedisChatRoomsInfoS.srem(pipe, None, *filtered_rooms_info_redis)
-            pipe = await RedisChatRoomsInfoS.sadd(
-                pipe, room.id, RedisChatRoomsInfoS.schema(
-                    id=room.id,
-                    type=room.type.name.lower(),
-                    user_profile_ids=user_profile_ids,
-                    user_profile_files=default_profile_images,
-                )
-            )
+
+        await RedisInfoByRoomS.hset(pipe, room.id, data=RedisChatRoomInfoS(
+            id=room.id,
+            type=room.type.name.lower(),
+            user_profile_ids=user_profile_ids,
+            user_profile_files=default_profile_images,
+            connected_user_profile_ids=set(),
+        ))
         await pipe.execute()
 
     return ChatRoomS.from_orm(room)
@@ -429,7 +389,7 @@ async def chat(
         try:
             # 방 데이터 추출
             try:
-                await redis_handler.get_room(room_id, ChatRoomCRUD(session), sync=True)
+                room_redis, _ = await redis_handler.get_room(room_id, ChatRoomCRUD(session), sync=True)
             except Exception as e:
                 raise WebSocketDisconnect(
                     code=status.WS_1007_INVALID_FRAME_PAYLOAD_DATA,
@@ -438,7 +398,7 @@ async def chat(
 
             # 유저가 속한 방 데이터 추출
             try:
-                await redis_handler.get_room_by_user_profile(
+                room_by_profile_redis, _ = await redis_handler.get_room_by_user_profile(
                     room_id, user_profile_id, ChatRoomUserAssociationCRUD(session), sync=True, raise_exception=True
                 )
             except Exception as e:
@@ -477,6 +437,95 @@ async def chat(
         raised_errors = set()
 
         try:
+            async with async_session() as session:
+                crud_room = ChatRoomCRUD(session)
+                crud_room_user_mapping = ChatRoomUserAssociationCRUD(session)
+
+                # 방 데이터 추출
+                try:
+                    room_redis, _ = await redis_handler.get_room(
+                        room_id, crud_room, sync=True, raise_exception=True
+                    )
+                except Exception as exc:
+                    raise WebSocketDisconnect(
+                        code=status.WS_1000_NORMAL_CLOSURE,
+                        reason=f'Failed to get room. {exc}'
+                    )
+                # 유저에 연결된 방 데이터 추출
+                try:
+                    room_by_profile_redis, _ = await redis_handler.get_room_by_user_profile(
+                        room_id, user_profile_id, crud_room_user_mapping,
+                        sync=True, raise_exception=True
+                    )
+                except Exception as exc:
+                    raise WebSocketDisconnect(
+                        code=status.WS_1000_NORMAL_CLOSURE,
+                        reason=f'Failed to get room for user profile. {exc}'
+                    )
+
+                # 방에 웹소켓 연결된 유저 프로필 ID 추가
+                room_redis.add_connected_profile_id(user_profile_id)
+                await RedisInfoByRoomS.hset(
+                    redis_handler.redis, room_id,
+                    field='connected_profile_ids', value=room_redis.connected_profile_ids
+                )
+
+                # 채팅방 unread_msg_cnt = 0 설정 (채팅방 접속 시, 모두 읽음 처리)
+                if room_by_profile_redis.unread_msg_cnt > 0:
+                    async with redis_handler.lock(
+                        key=RedisChatRoomsByUserProfileS.get_lock_key(user_profile_id)
+                    ):
+                        async with redis_handler.pipeline() as pipe:
+                            pipe = await RedisChatRoomsByUserProfileS.zrem(
+                                pipe, user_profile_id, room_by_profile_redis
+                            )
+                            room_by_profile_redis.unread_msg_cnt = 0
+                            pipe = await RedisChatRoomsByUserProfileS.zadd(
+                                pipe, user_profile_id, room_by_profile_redis
+                            )
+                            await pipe.execute()
+
+                async with redis_handler.lock(key=RedisChatHistoriesByRoomS.get_lock_key(room_id)):
+                    chat_histories_redis: List[RedisChatHistoryByRoomS] = (
+                        await RedisChatHistoriesByRoomS.zrevrange(redis_handler.redis, room_id)
+                    )
+                    target_histories_redis: List[Tuple[RedisChatHistoryByRoomS, List[int]]] = []
+                    # 최근 읽음 처리 동기화 안된 채팅 내역 추출
+                    for h in chat_histories_redis:
+                        if (
+                            len(set(h.read_user_ids) & set(room_redis.connected_profile_ids))
+                            != len(room_redis.connected_profile_ids)
+                        ):
+                            sync_read_user_ids = list(set(h.read_user_ids) | set(room_redis.connected_profile_ids))
+                            target_histories_redis.append((h, sync_read_user_ids))
+                        else:
+                            break
+
+                    # 채팅 내역 읽음 처리
+                    if target_histories_redis:
+                        async with redis_handler.pipeline() as pipe:
+                            unsync, sync = [], []
+                            patch_histories_redis = []
+                            async for history, read_user_ids in async_iter(target_histories_redis):
+                                unsync.append(deepcopy(history))
+                                history.read_user_ids = read_user_ids
+                                sync.append(history)
+                                patch_histories_redis.append(RedisChatHistoryPatchS(
+                                    id=history.id,
+                                    redis_id=history.redis_id,
+                                    user_profile_id=history.user_profile_id,
+                                    is_active=history.is_active,
+                                    read_user_ids=history.read_user_ids
+                                ))
+                            pipe = await RedisChatHistoriesByRoomS.zrem(pipe, room_id, *unsync)
+                            pipe = await RedisChatHistoriesByRoomS.zadd(pipe, room_id, sync)
+                            await pipe.execute()
+
+                        await pub.publish(f'pubsub:room:{room_id}:chat', ChatSendFormS(
+                            type=ChatType.UPDATE,
+                            data=ChatSendDataS(patch_histories=patch_histories_redis)
+                        ).json())
+
             while True:
                 data = await ws.receive_json()
                 if not data:
@@ -636,52 +685,66 @@ async def chat(
                         # 업데이트 요청
                         elif request_s.type == ChatType.UPDATE:
                             patch_histories_redis: List[RedisChatHistoryPatchS] = []
+                            # 채팅 내역 상태를 업데이트 하는 경우
+                            if not request_s.data.history_redis_ids:
+                                raise WebSocketDisconnect(
+                                    code=status.WS_1007_INVALID_FRAME_PAYLOAD_DATA,
+                                    reason='Not exists chat history redis ids.'
+                                )
 
-                            # 채팅 내역 조회 될 때마다 읽음 처리 하는 경우
-                            if request_s.data.is_read:
-                                if room_by_profile_redis.unread_msg_cnt > 0:
-                                    async with redis_handler.lock(
-                                        key=RedisChatRoomsByUserProfileS.get_lock_key(user_profile_id)
-                                    ):
-                                        async with redis_handler.pipeline(transaction=True) as pipe:
-                                            # 해당 방의 unread_msg_cnt = 0 설정 (채팅방 접속 시, 0으로 초기화)
-                                            pipe = await RedisChatRoomsByUserProfileS.zrem(
-                                                pipe, user_profile_id, room_by_profile_redis
-                                            )
-                                            room_by_profile_redis.unread_msg_cnt = 0
-                                            pipe = await RedisChatRoomsByUserProfileS.zadd(
-                                                pipe, user_profile_id, room_by_profile_redis
-                                            )
-                                            await pipe.execute()
+                            # 업데이트 필요한 필드 확인
+                            update_fields = (ChatHistory.is_active.name,)
+                            update_target_redis: List[RedisChatHistoryByRoomS] = []
+                            update_target_db: List[str] = []
+                            update_values_db: Dict[str, Any] = {}
 
-                                async with redis_handler.lock(key=RedisChatHistoriesByRoomS.get_lock_key(room_id)):
-                                    chat_histories_redis: List[RedisChatHistoryByRoomS] = (
-                                        await RedisChatHistoriesByRoomS.zrevrange(pub, room_id)
+                            async with redis_handler.lock(key=RedisChatHistoriesByRoomS.get_lock_key(room_id)):
+                                chat_histories_redis: List[RedisChatHistoryByRoomS] = (
+                                    await RedisChatHistoriesByRoomS.zrevrange(pub, room_id)
+                                )
+                                if not chat_histories_redis:
+                                    raise WebSocketDisconnect(
+                                        code=status.WS_1007_INVALID_FRAME_PAYLOAD_DATA,
+                                        reason='Not exists chat histories in the room.'
                                     )
-                                    target_histories_redis: List[RedisChatHistoryByRoomS] = []
-                                    # 최근 읽음 처리 안된 내역 추출
-                                    for h in chat_histories_redis:
-                                        if user_profile_id not in h.read_user_ids:
-                                            target_histories_redis.append(h)
-                                        else:
-                                            break
-
-                                    # 최근 읽음 처리 안된 내역 업데이트
-                                    if target_histories_redis:
-                                        async with redis_handler.pipeline() as pipe:
+                                async with redis_handler.pipeline() as pipe:
+                                    for redis_id in request_s.data.history_redis_ids:
+                                        duplicated_histories_redis: List[RedisChatHistoryByRoomS] = [
+                                            h for h in chat_histories_redis if h.redis_id == redis_id
+                                        ]
+                                        history_redis: RedisChatHistoryByRoomS = (
+                                            duplicated_histories_redis and duplicated_histories_redis[0]
+                                        )
+                                        copied_history_redis: RedisChatHistoryByRoomS = (
+                                            history_redis and deepcopy(history_redis)
+                                        )
+                                        update_redis = False
+                                        for f in update_fields:
+                                            if getattr(request_s.data, f) is None:
+                                                continue
+                                            if duplicated_histories_redis:
+                                                # 기존 데이터와 다른 경우 업데이트 설정
+                                                if getattr(request_s.data, f) != getattr(
+                                                    duplicated_histories_redis[0], f
+                                                ):
+                                                    setattr(copied_history_redis, f, getattr(request_s.data, f))
+                                                    update_redis = True
+                                            else:
+                                                update_values_db.update({f: getattr(request_s.data, f)})
+                                        if update_redis:
+                                            update_target_redis.append(copied_history_redis)
                                             pipe = await RedisChatHistoriesByRoomS.zrem(
-                                                pipe, room_id, *target_histories_redis
+                                                pipe, room_id, *duplicated_histories_redis
                                             )
-                                            for h in target_histories_redis:
-                                                h.read_user_ids = list(
-                                                    set(h.read_user_ids) | {user_profile_id}
-                                                )
-                                            pipe = await RedisChatHistoriesByRoomS.zadd(
-                                                pipe, room_id, target_histories_redis
-                                            )
-                                            await pipe.execute()
-
-                                        for h in target_histories_redis:
+                                        if update_values_db:
+                                            update_target_db.append(redis_id)
+                                    # Redis 에 저장되어 있는 데이터 업데이트
+                                    if update_target_redis:
+                                        pipe = await redis_handler.update_histories_by_room(
+                                            room_id, update_target_redis, pipe
+                                        )
+                                        await pipe.execute()
+                                        for h in update_target_redis:
                                             patch_histories_redis.append(RedisChatHistoryPatchS(
                                                 id=h.id,
                                                 redis_id=h.redis_id,
@@ -689,96 +752,28 @@ async def chat(
                                                 is_active=h.is_active,
                                                 read_user_ids=h.read_user_ids
                                             ))
-                            # 채팅 내역 상태를 업데이트 하는 경우
-                            else:
-                                if not request_s.data.history_redis_ids:
-                                    raise WebSocketDisconnect(
-                                        code=status.WS_1007_INVALID_FRAME_PAYLOAD_DATA,
-                                        reason='Not exists chat history redis ids.'
-                                    )
 
-                                # 업데이트 필요한 필드 확인
-                                update_fields = (ChatHistory.is_active.name,)
-                                update_target_redis: List[RedisChatHistoryByRoomS] = []
-                                update_target_db: List[str] = []
-                                update_values_db: Dict[str, Any] = {}
-
-                                async with redis_handler.lock(key=RedisChatHistoriesByRoomS.get_lock_key(room_id)):
-                                    chat_histories_redis: List[RedisChatHistoryByRoomS] = (
-                                        await RedisChatHistoriesByRoomS.zrevrange(pub, room_id)
-                                    )
-                                    if not chat_histories_redis:
-                                        raise WebSocketDisconnect(
-                                            code=status.WS_1007_INVALID_FRAME_PAYLOAD_DATA,
-                                            reason='Not exists chat histories in the room.'
-                                        )
-                                    async with redis_handler.pipeline() as pipe:
-                                        for redis_id in request_s.data.history_redis_ids:
-                                            duplicated_histories_redis: List[RedisChatHistoryByRoomS] = [
-                                                h for h in chat_histories_redis if h.redis_id == redis_id
-                                            ]
-                                            history_redis: RedisChatHistoryByRoomS = (
-                                                duplicated_histories_redis and duplicated_histories_redis[0]
-                                            )
-                                            copied_history_redis: RedisChatHistoryByRoomS = (
-                                                history_redis and deepcopy(history_redis)
-                                            )
-                                            update_redis = False
-                                            for f in update_fields:
-                                                if getattr(request_s.data, f) is None:
-                                                    continue
-                                                if duplicated_histories_redis:
-                                                    # 기존 데이터와 다른 경우 업데이트 설정
-                                                    if getattr(request_s.data, f) != getattr(
-                                                        duplicated_histories_redis[0], f
-                                                    ):
-                                                        setattr(copied_history_redis, f, getattr(request_s.data, f))
-                                                        update_redis = True
-                                                else:
-                                                    update_values_db.update({f: getattr(request_s.data, f)})
-                                            if update_redis:
-                                                update_target_redis.append(copied_history_redis)
-                                                pipe = await RedisChatHistoriesByRoomS.zrem(
-                                                    pipe, room_id, *duplicated_histories_redis
-                                                )
-                                            if update_values_db:
-                                                update_target_db.append(redis_id)
-                                        # Redis 에 저장되어 있는 데이터 업데이트
-                                        if update_target_redis:
-                                            pipe = await redis_handler.update_histories_by_room(
-                                                room_id, update_target_redis, pipe
-                                            )
-                                            await pipe.execute()
-                                            for h in update_target_redis:
-                                                patch_histories_redis.append(RedisChatHistoryPatchS(
-                                                    id=h.id,
-                                                    redis_id=h.redis_id,
-                                                    user_profile_id=h.user_profile_id,
-                                                    is_active=h.is_active,
-                                                    read_user_ids=h.read_user_ids
-                                                ))
-
-                                # Redis 에 저장되어 있지 않은 history_ids 에 한해 DB 업데이트
-                                if update_target_db:
-                                    await crud_chat_history.update(
-                                        conditions=(ChatHistory.redis_id.in_(update_target_db),),
-                                        **update_values_db
-                                    )
-                                    await session.commit()
-                                    updated_histories_db: List[ChatHistory] = await crud_chat_history.list(
-                                        conditions=(ChatHistory.redis_id.in_(update_target_db),),
-                                        options=[selectinload(ChatHistory.user_profile_mapping)]
-                                    )
-                                    for h in updated_histories_db:
-                                        patch_histories_redis.append(RedisChatHistoryPatchS(
-                                            id=h.id,
-                                            redis_id=h.redis_id,
-                                            user_profile_id=h.user_profile_id,
-                                            is_active=h.is_active,
-                                            read_user_ids=[
-                                                m.user_profile_id for m in h.user_profile_mapping if m.is_read
-                                            ]
-                                        ))
+                            # Redis 에 저장되어 있지 않은 history_ids 에 한해 DB 업데이트
+                            if update_target_db:
+                                await crud_chat_history.update(
+                                    conditions=(ChatHistory.redis_id.in_(update_target_db),),
+                                    **update_values_db
+                                )
+                                await session.commit()
+                                updated_histories_db: List[ChatHistory] = await crud_chat_history.list(
+                                    conditions=(ChatHistory.redis_id.in_(update_target_db),),
+                                    options=[selectinload(ChatHistory.user_profile_mapping)]
+                                )
+                                for h in updated_histories_db:
+                                    patch_histories_redis.append(RedisChatHistoryPatchS(
+                                        id=h.id,
+                                        redis_id=h.redis_id,
+                                        user_profile_id=h.user_profile_id,
+                                        is_active=h.is_active,
+                                        read_user_ids=[
+                                            m.user_profile_id for m in h.user_profile_mapping if m.is_read
+                                        ]
+                                    ))
 
                             broadcast_response_s = ChatSendFormS(
                                 type=request_s.type,
@@ -792,36 +787,22 @@ async def chat(
                                 user_profile_id=user_profile_id,
                                 contents=request_s.data.text,
                                 type=ChatHistoryType.MESSAGE.name.lower(),
-                                read_user_ids=[user_profile_id],
+                                read_user_ids=list({user_profile_id} | set(room_redis.connected_profile_ids)),
                                 timestamp=now.timestamp(),
                                 date=now.date().isoformat(),
                                 is_active=True
                             )
                             await RedisChatHistoriesByRoomS.zadd(pub, room_id, chat_history_redis)
+
                             # 각 유저 별 해당 방의 unread_msg_cnt 업데이트
                             for p in user_profiles_redis:
                                 if p.id == user_profile_id:
                                     continue
-                                _unread_msg_cnt = 1
-                                _room_by_profile_redis, _ = await redis_handler.get_room_by_user_profile(
-                                    room_id, p.id, crud_room_user_mapping, sync=True
+                                await redis_handler.update_unread_msg_cnt(
+                                    room_id, p.id, crud_room_user_mapping, now.timestamp()
                                 )
-                                if _room_by_profile_redis:
-                                    async with redis_handler.lock(key=RedisChatRoomsByUserProfileS.get_lock_key(p.id)):
-                                        async with redis_handler.pipeline() as pipe:
-                                            pipe = await RedisChatRoomsByUserProfileS.zrem(
-                                                pipe, p.id, _room_by_profile_redis
-                                            )
-                                            _unread_msg_cnt += _room_by_profile_redis.unread_msg_cnt
-                                            pipe = await RedisChatRoomsByUserProfileS.zadd(
-                                                pipe, p.id, RedisChatRoomsByUserProfileS.schema(
-                                                    id=_room_by_profile_redis.id,
-                                                    name=_room_by_profile_redis.name,
-                                                    unread_msg_cnt=_unread_msg_cnt,
-                                                    timestamp=now.timestamp()
-                                                )
-                                            )
-                                            await pipe.execute()
+
+
                             broadcast_response_s = ChatSendFormS(
                                 type=request_s.type,
                                 data=ChatSendDataS(history=chat_history_redis)
@@ -879,7 +860,7 @@ async def chat(
                                 redis_id=redis_id,
                                 user_profile_id=user_profile_id,
                                 files=files_s,
-                                read_user_ids=[user_profile_id],
+                                read_user_ids=list({user_profile_id} | set(room_redis.connected_profile_ids)),
                                 type=chat_history_db.type.name.lower(),
                                 timestamp=now.timestamp(),
                                 date=now.date().isoformat(),
@@ -889,26 +870,11 @@ async def chat(
 
                             # 각 유저 별 해당 방의 unread_msg_cnt 업데이트
                             for p in user_profiles_redis:
-                                _unread_msg_cnt = 1
-                                _room_by_profile_redis, _ = await redis_handler.get_room_by_user_profile(
-                                    room_id, p.id, crud_room_user_mapping, sync=True
+                                if p.id == user_profile_id:
+                                    continue
+                                await redis_handler.update_unread_msg_cnt(
+                                    room_id, p.id, crud_room_user_mapping, now.timestamp()
                                 )
-                                if _room_by_profile_redis:
-                                    async with redis_handler.lock(key=RedisChatRoomsByUserProfileS.get_lock_key(p.id)):
-                                        async with redis_handler.pipeline() as pipe:
-                                            pipe = await RedisChatRoomsByUserProfileS.zrem(
-                                                pipe, p.id, _room_by_profile_redis
-                                            )
-                                            _unread_msg_cnt += _room_by_profile_redis.unread_msg_cnt
-                                            pipe = await RedisChatRoomsByUserProfileS.zadd(
-                                                pipe, p.id, RedisChatRoomsByUserProfileS.schema(
-                                                    id=_room_by_profile_redis.id,
-                                                    name=_room_by_profile_redis.name,
-                                                    unread_msg_cnt=_unread_msg_cnt,
-                                                    timestamp=now.timestamp()
-                                                )
-                                            )
-                                            await pipe.execute()
 
                             broadcast_response_s = ChatSendFormS(
                                 type=request_s.type,
@@ -1000,12 +966,11 @@ async def chat(
                             )
 
                             # 방 정보 업데이트
-                            async with redis_handler.lock(key=RedisChatRoomsInfoS.get_lock_key()):
+                            async with redis_handler.lock(key=RedisInfoByRoomS.get_lock_key()):
                                 async with redis_handler.pipeline() as pipe:
-                                    pipe = await RedisChatRoomsInfoS.srem(pipe, None, room_redis)
                                     room_redis.user_profile_ids = [p.id for p in total_profiles]
                                     room_redis.user_profile_files = total_profile_images_redis
-                                    pipe = await RedisChatRoomsInfoS.sadd(pipe, None, room_redis)
+                                    await RedisInfoByRoomS.hset(redis_handler.redis, room_id, data=room_redis)
                                     await pipe.execute()
 
                             for target_profile in total_profiles:
@@ -1060,7 +1025,7 @@ async def chat(
                                 user_profile_id=user_profile_id,
                                 contents=f'{user_profile_redis.nickname}님이 {target_msg}님을 초대했습니다.',
                                 type=ChatHistoryType.NOTICE.name.lower(),
-                                read_user_ids=[user_profile_id],
+                                read_user_ids=list({user_profile_id} | set(room_redis.connected_profile_ids)),
                                 timestamp=now.timestamp(),
                                 date=now.date().isoformat(),
                                 is_active=True
@@ -1134,24 +1099,29 @@ async def chat(
                                                     pipe, (room_id, profile_id), *remove_profile_redis
                                                 )
 
-                                    async with redis_handler.lock(key=RedisChatRoomsInfoS.get_lock_key()):
-                                        pipe = await RedisChatRoomsInfoS.srem(pipe, None, room_redis)
-                                        room_redis.user_profile_ids = [
-                                            i for i in room_redis.user_profile_ids if i != user_profile_id
-                                        ]
-                                        room_redis.user_profile_files = [
-                                            f for f in room_redis.user_profile_files
-                                            if f.user_profile_id != user_profile_id
-                                        ]
-                                        if room_db.is_active:
-                                            pipe = await RedisChatRoomsInfoS.sadd(pipe, None, room_redis)
+                                    async with redis_handler.lock(key=RedisInfoByRoomS.get_lock_key()):
+                                        if not room_db.is_active:
+                                            await RedisInfoByRoomS.delete(redis_handler.redis, room_id)
+                                        else:
+                                            room_redis.user_profile_ids = [
+                                                i for i in room_redis.user_profile_ids if i != user_profile_id
+                                            ]
+                                            room_redis.user_profile_files = [
+                                                f for f in room_redis.user_profile_files
+                                                if f.user_profile_id != user_profile_id
+                                            ]
+                                            room_redis.connected_profile_ids = [
+                                                profile_id for profile_id in room_redis.connected_profile_ids
+                                                if profile_id != user_profile_id
+                                            ]
+                                            await RedisInfoByRoomS.hset(redis_handler.redis, room_id, data=room_redis)
 
                                     chat_history_redis: RedisChatHistoryByRoomS = RedisChatHistoryByRoomS(
                                         redis_id=uuid.uuid4().hex,
                                         user_profile_id=user_profile_id,
                                         contents=f'{user_profile_redis.nickname}님이 나갔습니다.',
                                         type=ChatHistoryType.NOTICE.name.lower(),
-                                        read_user_ids=[user_profile_id],
+                                        read_user_ids=list({user_profile_id} | set(room_redis.connected_profile_ids)),
                                         timestamp=now.timestamp(),
                                         date=now.date().isoformat(),
                                         is_active=True
@@ -1172,7 +1142,7 @@ async def chat(
                         if broadcast_response_s:
                             await pub.publish(f'pubsub:room:{room_id}:chat', broadcast_response_s.json())
 
-                    except (WebSocketDisconnect, ConnectionClosedOK, ConnectionClosedError) as exc:
+                    except (WebSocketDisconnect, WebSocketException) as exc:
                         raise exc
                     except Exception as exc:
                         if exc.__class__.__name__ not in raised_errors:
@@ -1203,8 +1173,17 @@ async def chat(
         except asyncio.CancelledError as exc:
             await psub.close()
             logger.error(get_log_error(exc))
-
-    await redis_handler.handle_pubsub(websocket, producer_handler, consumer_handler, logger)
+    try:
+        await redis_handler.handle_pubsub(websocket, producer_handler, consumer_handler, logger)
+    except:
+        room_redis.connected_profile_ids = [
+            profile_id for profile_id in room_redis.connected_profile_ids
+            if profile_id != user_profile_id
+        ]
+        await RedisInfoByRoomS.hset(
+            redis_handler.redis, room_id,
+            field='connected_profile_ids', value=room_redis.connected_profile_ids
+        )
 
 
 @router.websocket('/followings/{user_profile_id}')
@@ -1277,7 +1256,7 @@ async def chat_followings(websocket: WebSocket, user_profile_id: int):
                                     ) for f in user_profile.followings
                                 ])
             await websocket.send_json(jsonable_encoder(followings))
-        except (WebSocketDisconnect, ConnectionClosedOK, ConnectionClosedError) as e:
+        except (WebSocketDisconnect, WebSocketException) as e:
             logger.exception(get_log_error(e))
             raise e
         except Exception as e:

--- a/server/api/v1/user.py
+++ b/server/api/v1/user.py
@@ -119,6 +119,7 @@ async def signup(user_s: UserCreateS, session: AsyncSession = Depends(get_async_
             )
         )
     )
+    await redis_handler.redis.close()
 
     return UserS.from_orm(user)
 
@@ -419,7 +420,7 @@ async def update_relationship(
         ]
 
         if duplicated_following_redis:
-            async with redis_handler.pipeline(transaction=True) as pipe:
+            async with redis_handler.pipeline() as pipe:
                 pipe = await RedisFollowingsByUserProfileS.srem(pipe, user_profile_id, *duplicated_following_redis)
                 following_redis = duplicated_following_redis[-1]
                 for k, v in values.items():

--- a/server/core/externals/redis/schemas.py
+++ b/server/core/externals/redis/schemas.py
@@ -2,7 +2,8 @@ from typing import List, Optional
 
 from pydantic import BaseModel
 
-from server.core.externals.redis.mixin import SortedSetCollectionMixin, SetCollectionMixin
+from server.core.externals.redis.mixin import SortedSetCollectionMixin, SetCollectionMixin, HashCollectionMixin, \
+    ScanMixin
 
 
 class RedisFileBaseS(BaseModel):
@@ -34,7 +35,7 @@ class RedisUserProfileS(BaseModel):
     identity_id: str
     nickname: str
     image: Optional[RedisUserImageFileS] = None
-    files: Optional[List[RedisUserImageFileS]] = []
+    files: List[RedisUserImageFileS] = []
 
 
 class RedisFollowingS(RedisUserProfileS):
@@ -62,7 +63,7 @@ class RedisChatHistoryByRoomS(BaseModel):
     user_profile_id: int
     contents: Optional[str] = None
     type: str
-    files: Optional[List[RedisChatHistoryFileS]] = []
+    files: List[RedisChatHistoryFileS] = []
     read_user_ids: List[int] = []
     timestamp: float | int
     date: str
@@ -72,8 +73,13 @@ class RedisChatHistoryByRoomS(BaseModel):
 class RedisChatRoomInfoS(BaseModel):
     id: int
     type: str
-    user_profile_ids: List[int]
-    user_profile_files: Optional[List[RedisUserImageFileS]] = []
+    user_profile_ids: List[int] = []
+    user_profile_files: List[RedisUserImageFileS] = []
+    connected_profile_ids: List[int] = []
+
+    def add_connected_profile_id(self, profile_id: int):
+        if profile_id not in self.connected_profile_ids:
+            self.connected_profile_ids.append(profile_id)
 
 
 class RedisChatRoomByUserProfileS(BaseModel):
@@ -91,8 +97,8 @@ class RedisFollowingByUserProfileS(RedisFollowingS):
     ...
 
 
-class RedisChatRoomsInfoS(SetCollectionMixin):
-    format = 'rooms'
+class RedisInfoByRoomS(HashCollectionMixin, ScanMixin):
+    format = 'room:{}:info'
     schema = RedisChatRoomInfoS
 
 

--- a/server/core/externals/redis/schemas.py
+++ b/server/core/externals/redis/schemas.py
@@ -2,8 +2,9 @@ from typing import List, Optional
 
 from pydantic import BaseModel
 
-from server.core.externals.redis.mixin import SortedSetCollectionMixin, SetCollectionMixin, HashCollectionMixin, \
-    ScanMixin
+from server.core.externals.redis.mixin import (
+    SortedSetCollectionMixin, SetCollectionMixin, HashCollectionMixin, ScanMixin
+)
 
 
 class RedisFileBaseS(BaseModel):

--- a/server/core/utils/__init__.py
+++ b/server/core/utils/__init__.py
@@ -1,5 +1,6 @@
 import random
 import string
+from typing import Iterable
 
 import phonenumbers
 from passlib.context import CryptContext
@@ -101,3 +102,8 @@ def generate_random_string(
     for _ in range(length):
         random_str += random.choice(words)
     return random_str
+
+
+async def async_iter(iterable: Iterable):
+    for v in iterable:
+        yield v

--- a/server/main.py
+++ b/server/main.py
@@ -39,7 +39,7 @@ async def init_chat_room_redis():
     room_keys: List[str] = (await RedisInfoByRoomS.scan(redis))[1]
     if room_keys:
         await RedisInfoByRoomS.delete(redis, *room_keys, raw_key=True)
-    redis.close()
+    await redis.close()
 
 
 @app.on_event("startup")


### PR DESCRIPTION
**작업 내용**
- 메시지 읽음 처리 동기화 로직 변경
```
기존: Vue 에서 chatType 이 'lookup', 'message', 'file', 'invite' 일 때 update 메시지 전달 -> 서버에서 메시지 읽음 처리 동기화

개선: 채팅방 웹소켓 연결 시, 연결된 유저 프로필 ID 저장 및 메시지 읽음 처리 동기화 (웹소켓 부하 감소)
``` 
- 채팅방 데이터가 저장되는  redis collection 변경 
```
기존: Set collection 사용하여 전체 채팅방 데이터 저장
개선: Hash collection 사용하여 각 채팅방 데이터 저장 (collection 세분화 -> 레디스 부하 감소)
```